### PR TITLE
Reduce package size

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@socio-development/generator",
-  "version": "0.1.0-alpha.4",
+  "version": "0.1.0-alpha.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@socio-development/generator",
-      "version": "0.1.0-alpha.4",
+      "version": "0.1.0-alpha.5",
       "license": "MIT",
       "devDependencies": {
         "@socio-development/logger": "^0.1.0-alpha.0",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A code generator that provides a reliable way of creating files in your project. Excellent for generating type definitions.",
   "author": "CasperSocio (https://github.com/CasperSocio)",
   "scripts": {
-    "build": "tsc",
+    "build": "rm -rf dist && tsc",
     "dev": "ts-node src/sandbox/main.ts",
     "prepare": "husky",
     "test": "jest",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@socio-development/generator",
-  "version": "0.1.0-alpha.4",
+  "version": "0.1.0-alpha.5",
   "description": "A code generator that provides a reliable way of creating files in your project. Excellent for generating type definitions.",
   "author": "CasperSocio (https://github.com/CasperSocio)",
   "scripts": {


### PR DESCRIPTION
After replacing the logger, `dist` still contained the logger code which was accidentally added to the Alpha 4 deployment. I redeployed the package as Alpha 5 with a clean `dist` directory. I also modified the build script so that it always deletes `dist` before building again.